### PR TITLE
Fix webauthn signing by using sighash hex

### DIFF
--- a/libs/wallet/providers/web-authn/web-authn-utils.ts
+++ b/libs/wallet/providers/web-authn/web-authn-utils.ts
@@ -5,6 +5,14 @@ export const generateChallenge = (): Uint8Array => {
 	return crypto.getRandomValues(new Uint8Array(32));
 };
 
+export const hexToUint8Array = (hex: string): Uint8Array => {
+	const bytes = new Uint8Array(hex.length / 2);
+	for (let i = 0; i < hex.length; i += 2) {
+		bytes[i / 2] = Number.parseInt(hex.substring(i, i + 2), 16);
+	}
+	return bytes;
+}
+
 export const base64ToUint8Array = (base64: string): Uint8Array => {
 	const binaryString = atob(base64);
 	const len = binaryString.length;

--- a/libs/wallet/providers/web-authn/web-authn.ts
+++ b/libs/wallet/providers/web-authn/web-authn.ts
@@ -14,6 +14,7 @@ import { decryptWithPasskey, encryptWithPasskey } from "./encryption";
 import {
 	base64ToUint8Array,
 	derivePublicKeyFromPrivate,
+	hexToUint8Array,
 	encodeNpub,
 	uint8ArrayToBase64,
 } from "./web-authn-utils";
@@ -162,7 +163,7 @@ export class WebAuthnWallet implements WalletStrategy, WebAuthnProvider {
 	async signTx(transaction: Transaction): Promise<string> {
 		// TODO: it is failing in the backend
 		const privKey = await this.retrievePrivateKey();
-		const hash = sha256(new TextEncoder().encode(transaction));
+		const hash = hexToUint8Array(transaction);
 		console.log("hash", hash);
 		const signature = await schnorr.sign(hash, privKey);
 		console.log("signature", signature);


### PR DESCRIPTION
We shouldn't be performing the sha256 hash of the sighash again

Also probably best to change the input of the function to be a sighash? nit tho